### PR TITLE
feat(lenght): included new units of measurement

### DIFF
--- a/internal/converter/lenght.go
+++ b/internal/converter/lenght.go
@@ -1,18 +1,30 @@
 package converter
 
 func ConvertLength(value float64, from, to string) float64 {
-	// Conversion logic for length (mm, cm, m, etc.)
-	// Example: Convert meters to kilometers
-	switch from {
-	case "meter":
-		if to == "kilometer" {
-			return value / 1000
-		}
-	case "kilometer":
-		if to == "meter" {
-			return value * 1000
-		}
+	// Conversion factors to meters
+	conversionToMeter := map[string]float64{
+		"millimeter": 0.001,
+		"centimeter": 0.01,
+		"meter":      1,
+		"kilometer":  1000,
+		"inch":       0.0254,
+		"foot":       0.3048,
+		"yard":       0.9144,
+		"mile":       1609.34,
 	}
 
-	return value
+	// Check if the input units exist in the map
+	fromFactor, okFrom := conversionToMeter[from]
+	toFactor, okTo := conversionToMeter[to]
+
+	if !okFrom || !okTo {
+		// If either the "from" or "to" unit is invalid, return the original value
+		return value
+	}
+
+	// Convert the value to meters first, then to the target unit
+	valueInMeters := value * fromFactor
+	convertedValue := valueInMeters / toFactor
+
+	return convertedValue
 }

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -2,35 +2,88 @@
 <html>
 <head>
     <title>Unit Converter</title>
+    <script>
+        function updateOptions() {
+            const type = document.getElementById("type").value;
+            const fromSelect = document.getElementById("from");
+            const toSelect = document.getElementById("to");
+
+            let fromOptions = [];
+            let toOptions = [];
+
+            // Define the options based on the selected type
+            if (type === "length") {
+                fromOptions = [
+                    { value: "meter", text: "Meter" },
+                    { value: "kilometer", text: "Kilometer" },
+                    { value: "millimeter", text: "Millimeter" },
+                    { value: "centimeter", text: "Centimeter" },
+                ];
+                toOptions = fromOptions;
+            } else if (type === "weight") {
+                fromOptions = [
+                    { value: "gram", text: "Gram" },
+                    { value: "kilogram", text: "Kilogram" },
+                ];
+                toOptions = fromOptions;
+            } else if (type === "temperature") {
+                fromOptions = [
+                    { value: "celsius", text: "Celsius" },
+                    { value: "fahrenheit", text: "Fahrenheit" },
+                ];
+                toOptions = fromOptions;
+            }
+
+            // Clear and update "From" select options
+            fromSelect.innerHTML = "";
+            toSelect.innerHTML = "";
+            fromOptions.forEach(function(option) {
+                let opt = document.createElement("option");
+                opt.value = option.value;
+                opt.text = option.text;
+                fromSelect.appendChild(opt);
+            });
+
+            // Update "To" select options
+            toOptions.forEach(function(option) {
+                let opt = document.createElement("option");
+                opt.value = option.value;
+                opt.text = option.text;
+                toSelect.appendChild(opt);
+            });
+        }
+    </script>
 </head>
-<body>
-    <h1>Unit Converter</h1>
-    <form action="/convert" method="POST">
-        <label>Type:</label>
-        <select name="type">
-            <option value="length">Length</option>
-            <option value="weight">Weight</option>
-            <option value="temperature">Temperature</option>
-        </select>
-        <br>
+<body onload="updateOptions()">
+<h1>Unit Converter</h1>
+<form action="/convert" method="POST">
+    <label>Type:</label>
+    <select name="type" id="type" onchange="updateOptions()">
+        <option value="length">Length</option>
+        <option value="weight">Weight</option>
+        <option value="temperature">Temperature</option>
+    </select>
+    <br>
 
-        <label>Value:</label>
-        <input type="number" name="value" required>
-        <br>
+    <label>Value:</label>
+    <input type="number" name="value" required>
+    <br>
 
-        <label>From:</label>
-        <input type="text" name="from" required>
-        <br>
+    <label>From:</label>
+    <select name="from" id="from">
+        <!-- Options will be dynamically populated -->
+    </select>
+    <br>
 
-        <label>To:</label>
-        <input type="text" name="to" required>
-        <br>
+    <label>To:</label>
+    <select name="to" id="to">
+        <!-- Options will be dynamically populated -->
+    </select>
+    <br>
 
-        <button type="submit">Convert</button>
-    </form>
-    <p>Result: {{.}}</p>
+    <button type="submit">Convert</button>
+</form>
+
+<p>Result: {{.}}</p>
 </body>
 </html>
-
-
-


### PR DESCRIPTION
# What does it do?
This update enhances the user experience by providing measurement unit options as dropdown lists. Additionally, more units have been added for length conversion.

Key Improvements:
- [x] Refactored the ConvertLength function to handle a wider range of measurement units.
- [x] Updated the template (layout.html) to render measurement types (Length, Temperature, Weight) as buttons.
- [x] Added JavaScript functions to dynamically update the available unit options based on the selected measurement type (Length, Temperature, or Weight).

# Motivation
The new version expands conversion capabilities beyond just meters and kilometers. It now supports conversions between additional units like `centimeters`, `millimeters`, and vice-versa.

Previously, the app was limited to handling only a few length units (meter, kilometer, centimeter, and millimeter). With this update, we’ve streamlined the input process by `restricting the user's options` to valid units through dropdowns.

The inclusion of JavaScript functions improves the dynamic behavior of the template, ensuring that the "From" and "To" `unit options update automatically based on the selected measurement type`. For example, when "Temperature" is selected, only temperature-related units (like Celsius, Fahrenheit, etc.) are displayed.

# How was it tested?
The following image evidences that the new units of measurement, millimeters and centimeters, are available in the dropdown list for units options
![Screenshot 2024-10-24 at 07 30 46](https://github.com/user-attachments/assets/13170238-836d-4542-a83f-695a74eab80f)
